### PR TITLE
Implemented first working pour functionality

### DIFF
--- a/src/bash/bin/crucible
+++ b/src/bash/bin/crucible
@@ -22,6 +22,14 @@ function get_shared_dir {
  fi
 }
 
+function get_main_file {
+  grep 'main_file' .crucible | cut -d'=' -f 2
+}
+
+function get_project_name {
+  grep 'project_name' .crucible | cut -d'=' -f 2
+}
+
 function generate_mould {
 	wget -q -O .mould "https://raw.githubusercontent.com/StealthyCoder/crucible/$CRUCIBLE_LOCATION/src/bash/core/mould.sh"
 }
@@ -111,6 +119,55 @@ function purge {
 	fi
 }
 
+function pour {
+  local UUID share_dir cur_dir temp_dir project_name main_file
+  UUID="$(get_uuid)"
+  cur_dir="$(pwd)"
+  share_dir="$(get_shared_dir)"
+  temp_dir="$(mktemp -d)"
+  project_name="$(get_project_name)"
+  
+  if [ ! -d "dist" ]
+  then
+    mkdir dist
+  fi
+
+  touch "$temp_dir/.lib" 
+  
+  cd "$share_dir" || exit 1
+  
+  shopt -s globstar
+  for f in ./**/*
+  do
+    if [ ! -d "$f" ]
+    then
+      t="$(mktemp)"
+      cat "$f" > "$t"
+      sed -i '/^require/d' "$t"
+      sed -i '/^\#/d' "$t"
+      cat "$t" >> "$temp_dir/.lib"
+      rm "$t"
+    fi
+  done
+  shopt -u globstar
+  
+  cd "$cur_dir" || exit 1
+  t="$(mktemp)"
+  main_file="$(get_main_file)"
+  cat "$main_file" > "$t"
+  sed -i '/^require/d' "$t"
+  sed -i 's/\.mould/\.lib/' "$t"
+  mv "$t" "/$temp_dir/$main_file"
+  chmod +x "/$temp_dir/$main_file"
+  
+  cd "$temp_dir" || exit 1
+  tar cf "$project_name.tar.gz" .lib "$main_file"
+  mv "$project_name.tar.gz" "$cur_dir/"
+  
+  cd "$cur_dir" || return
+  rm -r "$temp_dir"
+}
+
 case $1 in
 	init)
 		init
@@ -121,11 +178,15 @@ case $1 in
 	purge)
 		purge
 		;;
+  pour)
+    pour
+    ;;
 	"" | help)
 		echo -e "Possible values are:\\n"
 		echo "init - Initialise a directory as a Crucible project"
 		echo "update - Update current project with new version"
 		echo "purge - Remove all files belonging to this project"
+		echo "pour - Create a distributable tarball with script in there"
 		echo "help - Print this help message"
 		;;
 	*)

--- a/src/bash/bin/crucible
+++ b/src/bash/bin/crucible
@@ -130,6 +130,8 @@ function pour {
   if [ ! -d "dist" ]
   then
     mkdir dist
+  else
+    rm dist/*
   fi
 
   touch "$temp_dir/.lib" 


### PR DESCRIPTION
First pour functionality, it takes all the files whether they are required or not and puts them all in the same file called `.lib` and swaps out `source .mould` for `source .lib`.

Then it also removes all mentions to require in the main file. The distributable will be put in the dist folder. If there was one before it will be removed before. 